### PR TITLE
Do not fail if a namespace cannot be loaded.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,4 @@
+- `session_info()` now only lists loaded versions for namespaces which are already loaded.
 
 # 0.0.0.9000
 

--- a/R/dependent-packages.R
+++ b/R/dependent-packages.R
@@ -3,10 +3,13 @@ dependent_packages <- function(pkgs) {
   pkgs <- find_deps(pkgs, utils::installed.packages(), top_dep = NA)
   desc <- lapply(pkgs, utils::packageDescription)
 
+  loaded_pkgs <- pkgs %in% setdiff(loadedNamespaces(), "base")
+  loadedversion <- rep(NA_character_, length(pkgs))
+  loadedversion[loaded_pkgs] <- vapply(pkgs[loaded_pkgs], getNamespaceVersion, "")
   res <- data.frame(
     package = pkgs,
     ondiskversion = vapply(desc, function(x) x$Version, character(1)),
-    loadedversion = vapply(pkgs, getNamespaceVersion, ""),
+    loadedversion = loadedversion,
     path = vapply(desc, pkg_path, character(1)),
     attached = paste0("package:", pkgs) %in% search(),
     stringsAsFactors = FALSE,

--- a/R/package-info.R
+++ b/R/package-info.R
@@ -129,13 +129,16 @@ pkg_source <- function(desc) {
 
 print.packages_info <- function(x, ...) {
 
-  badloaded <- package_version(x$loadedversion) !=
+  unloaded <- is.na(x$loadedversion)
+  badloaded <- package_version(x$loadedversion, strict = FALSE) !=
                package_version(x$ondiskversion)
 
   px <- data.frame(
     package = x$package,
     "*"     = ifelse(x$attached, "*", ""),
-    version = paste0(x$loadedversion, ifelse(badloaded, " (!)", "")),
+    version = ifelse(unloaded,
+                     x$ondiskversion,
+                     paste0(x$loadedversion, ifelse(badloaded, " (!)", ""))),
     date    = x$date,
     source  = x$source,
     stringsAsFactors = FALSE,

--- a/tests/testthat/test-dependent-packages.R
+++ b/tests/testthat/test-dependent-packages.R
@@ -14,6 +14,12 @@ test_that("dependent_packages", {
   )
   mockery::stub(
     dependent_packages,
+    'base::loadedNamespaces',
+    function() ins
+  )
+
+  mockery::stub(
+    dependent_packages,
     'getNamespaceVersion',
     function(x) alldsc[[x]]$Version
   )


### PR DESCRIPTION
This fixes devtools failures when using sessioninfo

https://travis-ci.org/hadley/devtools/jobs/260288634#L823-L827