### PR TITLE
Documentation fixes 

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,6 +12,7 @@ LazyData: true
 URL: https://github.com/r-lib/sessioninfo#readme
 BugReports: https://github.com/r-lib/sessioninfo/issues
 RoxygenNote: 6.0.1.9000
+Roxygen: list(markdown = TRUE)
 Suggests:
     covr,
     mockery,

--- a/R/osname.R
+++ b/R/osname.R
@@ -5,7 +5,7 @@
 #' On macOS it includes the code names, on Linux it includes the
 #' distribution names and codenames if appropriate.
 #'
-#' It uses [utils::sesssionInfo()], but simplifies its output a bit
+#' It uses [utils::sessionInfo()], but simplifies its output a bit
 #' on Windows, to make it more concise.
 #'
 #' @return A character scalar.

--- a/R/session-info.R
+++ b/R/session-info.R
@@ -1,7 +1,7 @@
 
 #' Print session information
 #'
-#' This is [base::sessionInfo()] re-written from scratch to both exclude
+#' This is [utils::sessionInfo()] re-written from scratch to both exclude
 #' data that's rarely useful (e.g., the full collate string or base packages
 #' loaded) and include stuff you'd like to know (e.g., where a package was
 #' installed from).

--- a/man/os_name.Rd
+++ b/man/os_name.Rd
@@ -15,6 +15,6 @@ On macOS it includes the code names, on Linux it includes the
 distribution names and codenames if appropriate.
 }
 \details{
-It uses [utils::sesssionInfo()], but simplifies its output a bit
+It uses \code{\link[utils:sesssionInfo]{utils::sesssionInfo()}}, but simplifies its output a bit
 on Windows, to make it more concise.
 }

--- a/man/package_info.Rd
+++ b/man/package_info.Rd
@@ -16,23 +16,25 @@ false since base packages should always match the R version.}
 }
 \value{
 A data frame with columns:
-  * `package`: package name.
-  * `loadedversion`: package version. This is the version of the loaded
-    namespace if `pkgs` is `NULL`, and it is the version of the package
-    on disk otherwise. The two of them are almost always the same,
-    though.
-  * `ondiskversion`: package version (on the disk, which is sometimes
-    not the same as the loaded version).
-  * `path`: path to the package on disk.
-  * `attached`: logical, whether the package is attached to the search
-    path.
-  * `is_base`: logical, whether the package is a base package.
-  * `date`: the date the package was installed or built.
-  * `source`: where the package was installed from. E.g.
-    `CRAN`, `GitHub`, `local` (from the local machine), etc.
+\itemize{
+\item \code{package}: package name.
+\item \code{loadedversion}: package version. This is the version of the loaded
+namespace if \code{pkgs} is \code{NULL}, and it is the version of the package
+on disk otherwise. The two of them are almost always the same,
+though.
+\item \code{ondiskversion}: package version (on the disk, which is sometimes
+not the same as the loaded version).
+\item \code{path}: path to the package on disk.
+\item \code{attached}: logical, whether the package is attached to the search
+path.
+\item \code{is_base}: logical, whether the package is a base package.
+\item \code{date}: the date the package was installed or built.
+\item \code{source}: where the package was installed from. E.g.
+\code{CRAN}, \code{GitHub}, \code{local} (from the local machine), etc.
+}
 
-See [session_info()] for the description of the *printed* columns
-by `package_info` (as opposed to the *returned* columns).
+See \code{\link[=session_info]{session_info()}} for the description of the \emph{printed} columns
+by \code{package_info} (as opposed to the \emph{returned} columns).
 }
 \description{
 Information about the currently loaded packages, or about a chosen set

--- a/man/platform_info.Rd
+++ b/man/platform_info.Rd
@@ -8,16 +8,18 @@ platform_info()
 }
 \value{
 A list with elements:
-  * `version`: the R version string.
-  * `os`: the OS name in human readable format, see [osname()].
-  * `system`: CPU, and machine readable OS name, separated by a comma.
-  * `ui`: the user interface, e.g. `Rgui`, `RTerm`, etc. see `GUI`
-    in [base::.Platform].
-  * `language`: The current language setting. The `LANGUAGE` environment
-    variable, if set, or `(EN)` if unset.
-  * `collate`: Collation rule, from the current locale.
-  * `tz`: The current time zone.
-  * `date`: The current date.
+\itemize{
+\item \code{version}: the R version string.
+\item \code{os}: the OS name in human readable format, see \code{\link[=osname]{osname()}}.
+\item \code{system}: CPU, and machine readable OS name, separated by a comma.
+\item \code{ui}: the user interface, e.g. \code{Rgui}, \code{RTerm}, etc. see \code{GUI}
+in \link[base:.Platform]{base::.Platform}.
+\item \code{language}: The current language setting. The \code{LANGUAGE} environment
+variable, if set, or \code{(EN)} if unset.
+\item \code{collate}: Collation rule, from the current locale.
+\item \code{tz}: The current time zone.
+\item \code{date}: The current date.
+}
 }
 \description{
 Information about the current platform
@@ -27,6 +29,6 @@ platform_info()
 }
 \seealso{
 Similar functions and objects in the base packages:
-  [base::R.version.string], [utils::sessionInfo()], [base::version],
-  [base::.Platform], [base::Sys.getlocale()], [base::Sys.timezone()].
+\link[base:R.version.string]{base::R.version.string}, \code{\link[utils:sessionInfo]{utils::sessionInfo()}}, \link[base:version]{base::version},
+\link[base:.Platform]{base::.Platform}, \code{\link[base:Sys.getlocale]{base::Sys.getlocale()}}, \code{\link[base:Sys.timezone]{base::Sys.timezone()}}.
 }

--- a/man/session_info.Rd
+++ b/man/session_info.Rd
@@ -15,28 +15,30 @@ all dependencies of the package.}
 false since base packages should always match the R version.}
 }
 \description{
-This is [base::sessionInfo()] re-written from scratch to both exclude
+This is \code{\link[base:sessionInfo]{base::sessionInfo()}} re-written from scratch to both exclude
 data that's rarely useful (e.g., the full collate string or base packages
 loaded) and include stuff you'd like to know (e.g., where a package was
 installed from).
 }
 \details{
-Columns in the *printed* package list:
-* `package`: package name
-* `*`: whether the package is attached to the search path
-* `version`: package version. If the version is marked with `(!)` that
-  means that the loaded and the on-disk version of the package are
-  different.
-* `date`: when the package was built, if this information is available.
-  This is the `Date/Publication` or the `Built` field from
-  `DESCRIPTION`. (These are usually added automatically by R.)
-  Sometimes this data is not available, then it is `NA`.
-* `source`: where the package was built or installed from, if available.
-  Examples: `CRAN (R 3.3.2)`, `Github (r-lib/pkgbuild@8aab60b)`,
-  `Bioconductor`, `local`.
+Columns in the \emph{printed} package list:
+\itemize{
+\item \code{package}: package name
+\item \code{*}: whether the package is attached to the search path
+\item \code{version}: package version. If the version is marked with \code{(!)} that
+means that the loaded and the on-disk version of the package are
+different.
+\item \code{date}: when the package was built, if this information is available.
+This is the \code{Date/Publication} or the \code{Built} field from
+\code{DESCRIPTION}. (These are usually added automatically by R.)
+Sometimes this data is not available, then it is \code{NA}.
+\item \code{source}: where the package was built or installed from, if available.
+Examples: \code{CRAN (R 3.3.2)}, \code{Github (r-lib/pkgbuild@8aab60b)},
+\code{Bioconductor}, \code{local}.
+}
 
-See [package_info()] for the list of columns in the data frame that
-is *returned* (as opposed to *printed*).
+See \code{\link[=package_info]{package_info()}} for the list of columns in the data frame that
+is \emph{returned} (as opposed to \emph{printed}).
 }
 \examples{
 session_info()


### PR DESCRIPTION
* enabled markdown
* fixed a few typos

On my machine, the tests fail due to unrelated issues (e.g. can’t find `sessioninfo:::standardise_dep` etc). 