### PR TITLE
report LC_CTYPE in platform_info

### DIFF
--- a/R/platform-info.R
+++ b/R/platform-info.R
@@ -10,6 +10,7 @@
 #'   * `language`: The current language setting. The `LANGUAGE` environment
 #'     variable, if set, or `(EN)` if unset.
 #'   * `collate`: Collation rule, from the current locale.
+#'   * `ctype`: Native character encoding, from the current locale.
 #'   * `tz`: The current time zone.
 #'   * `date`: The current date.
 #'
@@ -29,6 +30,7 @@ platform_info <- function() {
     ui = .Platform$GUI,
     language = Sys.getenv("LANGUAGE", "(EN)"),
     collate = Sys.getlocale("LC_COLLATE"),
+    ctype = Sys.getlocale("LC_CTYPE"),
     tz = Sys.timezone(),
     date = format(Sys.Date())
   ), class = "platform_info")

--- a/man/platform_info.Rd
+++ b/man/platform_info.Rd
@@ -17,6 +17,7 @@ in \link[base:.Platform]{base::.Platform}.
 \item \code{language}: The current language setting. The \code{LANGUAGE} environment
 variable, if set, or \code{(EN)} if unset.
 \item \code{collate}: Collation rule, from the current locale.
+\item \code{ctype}: Native character encoding, from the current locale.
 \item \code{tz}: The current time zone.
 \item \code{date}: The current date.
 }

--- a/tests/testthat/test-platform-info.R
+++ b/tests/testthat/test-platform-info.R
@@ -5,7 +5,7 @@ test_that("platform_info", {
   pi <- platform_info()
   expect_equal(
     names(pi),
-    c("version", "os", "system", "ui", "language", "collate", "tz", "date")
+    c("version", "os", "system", "ui", "language", "collate", "ctype", "tz", "date")
   )
 
   ## This can be a variety of strings, e.g. "R Under development"


### PR DESCRIPTION
This is important for debugging character encoding problems, especially on Windows.