### PR TITLE
Do not consult "max.print" option when printing platform or package info

### DIFF
--- a/R/package-info.R
+++ b/R/package-info.R
@@ -145,7 +145,7 @@ print.packages_info <- function(x, ...) {
     check.names = FALSE
   )
 
-  print.data.frame(px, right = FALSE, row.names = FALSE)
+  print.data.frame(px, right = FALSE, row.names = FALSE, max = 99999)
 }
 
 #' @export

--- a/R/platform-info.R
+++ b/R/platform-info.R
@@ -38,7 +38,7 @@ platform_info <- function() {
 
 print.platform_info <- function(x, ...) {
   df <- data.frame(setting = names(x), value = unlist(x), stringsAsFactors = FALSE)
-  print(df, right = FALSE, row.names = FALSE)
+  print(df, right = FALSE, row.names = FALSE, max = 99999)
 }
 
 #' @export

--- a/tests/testthat/test-package-info.R
+++ b/tests/testthat/test-package-info.R
@@ -80,3 +80,11 @@ test_that("print.packages_info", {
     fixed = TRUE
   )
 })
+
+test_that("print.packages_info ignores max.print", {
+  info <- readRDS("fixtures/devtools-info.rda")
+  withr::local_options(list(max.print = 1))
+  out <- capture_output(print(info))
+  out <- tail(strsplit(out, split = "\n")[[1]], -1)
+  expect_length(out, nrow(info))
+})

--- a/tests/testthat/test-platform-info.R
+++ b/tests/testthat/test-platform-info.R
@@ -22,3 +22,11 @@ test_that("platform_info", {
 test_that("print.platform_info", {
   expect_output(print(platform_info()), "setting  value", fixed = TRUE)
 })
+
+test_that("print.platform_info ignores max.print", {
+  pi <- platform_info()
+  withr::local_options(list(max.print = 1))
+  out <- capture_output(print(pi))
+  out <- tail(strsplit(out, split = "\n")[[1]], -1)
+  expect_length(out, length(pi))
+})


### PR DESCRIPTION
If user has set "max.print" to something modest, `sessioninfo::session_info()` can print output that is frustratingly truncated. The message can be quite mystifying, since "max.print" constrains *entries*, but the message about hidden info refers to *rows*.

Via slack, we agreed to set `max` to a very large value inside `print.data.frame` here.

Below we only see 2 rows-worth of package info because each row contains 4 items and 2 * 4 = 8 < 10.

```
options(max.print=10)
sessioninfo::session_info()
#> ─ Session info ──────────────────────────────────────────────────────────
#>  setting  value                       
#>  version  R version 3.5.1 (2018-07-02)
#>  os       macOS Sierra 10.12.6        
#>  system   x86_64, darwin15.6.0        
#>  ui       X11                         
#>  language (EN)                        
#>  [ reached getOption("max.print") -- omitted 3 rows ]
#> 
#> ─ Packages ──────────────────────────────────────────────────────────────
#>  package     * version date       source        
#>  backports     1.1.2   2017-12-13 CRAN (R 3.5.0)
#>  clisymbols    1.2.0   2017-05-21 cran (@1.2.0) 
#>  [ reached getOption("max.print") -- omitted 14 rows ]
```