### PR TITLE
Work around an R 3.5.1-patched bug

### DIFF
--- a/R/package-info.R
+++ b/R/package-info.R
@@ -145,7 +145,8 @@ print.packages_info <- function(x, ...) {
     check.names = FALSE
   )
 
-  print.data.frame(px, right = FALSE, row.names = FALSE, max = 99999)
+  withr::local_options(list(max.print = 99999))
+  print.data.frame(px, right = FALSE, row.names = FALSE)
 }
 
 #' @export

--- a/R/platform-info.R
+++ b/R/platform-info.R
@@ -40,7 +40,8 @@ platform_info <- function() {
 
 print.platform_info <- function(x, ...) {
   df <- data.frame(setting = names(x), value = unlist(x), stringsAsFactors = FALSE)
-  print(df, right = FALSE, row.names = FALSE, max = 99999)
+  withr::local_options(list(max.print = 99999))
+  print(df, right = FALSE, row.names = FALSE)
 }
 
 #' @export

--- a/tests/testthat/test-package-info.R
+++ b/tests/testthat/test-package-info.R
@@ -85,6 +85,6 @@ test_that("print.packages_info ignores max.print", {
   info <- readRDS("fixtures/devtools-info.rda")
   withr::local_options(list(max.print = 1))
   out <- capture_output(print(info))
-  out <- tail(strsplit(out, split = "\n")[[1]], -1)
+  out <- tail(strsplit(out, split = "\r?\n")[[1]], -1)
   expect_length(out, nrow(info))
 })

--- a/tests/testthat/test-platform-info.R
+++ b/tests/testthat/test-platform-info.R
@@ -27,6 +27,6 @@ test_that("print.platform_info ignores max.print", {
   pi <- platform_info()
   withr::local_options(list(max.print = 1))
   out <- capture_output(print(pi))
-  out <- tail(strsplit(out, split = "\n")[[1]], -1)
+  out <- tail(strsplit(out, split = "\r?\n")[[1]], -1)
   expect_length(out, length(pi))
 })


### PR DESCRIPTION
R 3.5.1-patched ignores the max argument of print.default.