### PR TITLE
dependencies arg for package_info()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: sessioninfo
 Title: R Session Information
-Version: 1.0.1.9000
+Version: 1.0.1.9001
 Author: Gábor Csárdi, R core, Hadley Wickham, Winston Chang,
     Robert M Flight, Kirill Müller, Jim Hester
 Maintainer: Gábor Csárdi <csardi.gabor@gmail.com>

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,7 +11,7 @@ License: GPL-2
 LazyData: true
 URL: https://github.com/r-lib/sessioninfo#readme
 BugReports: https://github.com/r-lib/sessioninfo/issues
-RoxygenNote: 6.0.1.9000
+RoxygenNote: 6.1.0
 Roxygen: list(markdown = TRUE)
 Suggests:
     callr,

--- a/R/dependent-packages.R
+++ b/R/dependent-packages.R
@@ -1,6 +1,9 @@
 
-dependent_packages <- function(pkgs) {
-  pkgs <- find_deps(pkgs, utils::installed.packages(), top_dep = NA)
+dependent_packages <- function(pkgs, dependencies) {
+
+  ideps <- interpret_dependencies(dependencies)
+
+  pkgs <- find_deps(pkgs, utils::installed.packages(), ideps[[1]], ideps[[2]])
   desc <- lapply(pkgs, utils::packageDescription)
 
   loaded_pkgs <- pkgs %in% setdiff(loadedNamespaces(), "base")
@@ -31,12 +34,10 @@ pkg_path_disk <- function(desc) {
 }
 
 find_deps <- function(pkgs, available = utils::available.packages(),
-                      top_dep = TRUE, rec_dep = NA, include_pkgs = TRUE) {
+                      top_dep = c(dep_types_hard(), "Suggests"),
+                      rec_dep = dep_types_hard(), include_pkgs = TRUE) {
 
   if (length(pkgs) == 0 || identical(top_dep, FALSE)) return(character())
-
-  top_dep <- standardise_dep(top_dep)
-  rec_dep <- standardise_dep(rec_dep)
 
   if (length(top_dep) > 0) {
     top <- tools::package_dependencies(pkgs, db = available, which = top_dep)
@@ -60,16 +61,25 @@ find_deps <- function(pkgs, available = utils::available.packages(),
   unique(c(if (include_pkgs) pkgs, top_flat, rec_flat))
 }
 
-standardise_dep <- function(x) {
-  if (identical(x, NA)) {
-    c("Depends", "Imports", "LinkingTo")
-  } else if (isTRUE(x)) {
-    c("Depends", "Imports", "LinkingTo", "Suggests")
-  } else if (identical(x, FALSE)) {
-    character(0)
-  } else if (is.character(x)) {
-    x
+dep_types_hard <- function() c("Depends", "Imports", "LinkingTo")
+dep_types_soft <- function() c("Suggests", "Enhances")
+dep_types <- function() c(dep_types_hard(), dep_types_soft())
+
+is_na_scalar <- function(x) length(x) == 1 && is.na(x)
+
+interpret_dependencies <- function(dp) {
+  hard <- dep_types_hard()
+
+  if (isTRUE(dp)) {
+    list(c(hard, "Suggests"), hard)
+
+  } else if (identical(dp, FALSE)) {
+    list(character(), character())
+
+  } else if (is_na_scalar(dp)) {
+    list(hard, hard)
+
   } else {
-    stop("Dependencies must be a boolean or a character vector", call. = FALSE)
+    list(dp, dp)
   }
 }

--- a/R/package-info.R
+++ b/R/package-info.R
@@ -6,6 +6,8 @@
 #'   all dependencies of the package.
 #' @param include_base Include base packages in summary? By default this is
 #'   false since base packages should always match the R version.
+#' @param dependencies Whether to include the (recursive) dependencies
+#'   as well. See the `dependencies` argument of [utils::install.packages()].
 #' @return A data frame with columns:
 #'   * `package`: package name.
 #'   * `ondiskversion`: package version (on the disk, which is sometimes
@@ -36,12 +38,13 @@
 #' package_info()
 #' package_info("sessioninfo")
 
-package_info <- function(pkgs = NULL, include_base = FALSE) {
+package_info <- function(pkgs = NULL, include_base = FALSE,
+                         dependencies = NA) {
 
   if (is.null(pkgs)) {
     pkgs <- loaded_packages()
   } else {
-    pkgs <- dependent_packages(pkgs)
+    pkgs <- dependent_packages(pkgs, dependencies)
   }
 
   desc <- lapply(pkgs$package, utils::packageDescription, lib.loc = .libPaths())

--- a/man/package_info.Rd
+++ b/man/package_info.Rd
@@ -4,7 +4,7 @@
 \alias{package_info}
 \title{Information about the currently loaded packages, or about a chosen set}
 \usage{
-package_info(pkgs = NULL, include_base = FALSE)
+package_info(pkgs = NULL, include_base = FALSE, dependencies = NA)
 }
 \arguments{
 \item{pkgs}{Either a vector of package names or NULL. If \code{NULL},
@@ -13,6 +13,9 @@ all dependencies of the package.}
 
 \item{include_base}{Include base packages in summary? By default this is
 false since base packages should always match the R version.}
+
+\item{dependencies}{Whether to include the (recursive) dependencies
+as well. See the \code{dependencies} argument of \code{\link[utils:install.packages]{utils::install.packages()}}.}
 }
 \value{
 A data frame with columns:

--- a/tests/testthat/test-dependent-packages.R
+++ b/tests/testthat/test-dependent-packages.R
@@ -35,7 +35,7 @@ test_that("dependent_packages", {
   )
 
   exp <- dep[, setdiff(colnames(dep), c("path", "loadedpath"))]
-  tec <- dependent_packages("devtools")
+  tec <- dependent_packages("devtools", NA)
   tec <- tec[, setdiff(colnames(tec), c("path", "loadedpath"))]
   expect_equal(exp, tec)
 })
@@ -71,27 +71,5 @@ test_that("find_deps", {
   expect_equal(
     find_deps("foobar", top_dep = character(), rec_dep = character()),
     "foobar"
-  )
-})
-
-test_that("standardise_dep", {
-
-  cases <- list(
-    NA,
-    TRUE,
-    FALSE,
-    "Imports"
-  )
-
-  for (c in cases) {
-    expect_true(
-      all(standardise_dep(c) %in%
-          c("Depends", "Imports", "Suggests", "LinkingTo"))
-    )
-  }
-
-  expect_error(
-    standardise_dep(list(1,2,3)),
-    "Dependencies must be a boolean or a character"
   )
 })


### PR DESCRIPTION
To specify what kind of dependencies we want.

For the `FALSE` case, the output it not so minimal, now that we also print the lib path:
```r
❯ package_info("cli",  dependencies = FALSE)
 package * version    date       lib source
 cli       1.0.0.9002 2018-09-22 [1] Github (r-lib/cli@f46ce3f)

[1] /Users/gaborcsardi/r_pkgs
[2] /Library/Frameworks/R.framework/Versions/3.5/Resources/library
```

Closes #21.