### PR TITLE
Switch to Authors@R; normalize DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,26 +1,48 @@
 Package: sessioninfo
 Title: R Session Information
 Version: 1.1.1.9000
+Authors@R: 
+    c(person(given = "Gábor",
+             family = "Csárdi",
+             role = "cre",
+             email = "csardi.gabor@gmail.com"),
+      person(given = "Hadley",
+             family = "Wickham",
+             role = "aut"),
+      person(given = "Winston",
+             family = "Chang",
+             role = "aut"),
+      person(given = "Robert",
+             family = "Flight",
+             role = "aut"),
+      person(given = "Kirill",
+             family = "Müller",
+             role = "aut"),
+      person(given = "Jim",
+             family = "Hester",
+             role = "aut"),
+      person(given = "R Core team",
+             role = "ctb"))
 Author: Gábor Csárdi, R core, Hadley Wickham, Winston Chang,
     Robert M Flight, Kirill Müller, Jim Hester
 Maintainer: Gábor Csárdi <csardi.gabor@gmail.com>
-Description: Query and print information about the current R session.
-    It is similar to 'utils::sessionInfo()', but includes more information
-    about packages, and where they were installed from.
+Description: Query and print information about the current R
+    session.  It is similar to 'utils::sessionInfo()', but includes more
+    information about packages, and where they were installed from.
 License: GPL-2
-LazyData: true
 URL: https://github.com/r-lib/sessioninfo#readme
 BugReports: https://github.com/r-lib/sessioninfo/issues
-RoxygenNote: 6.1.0
-Roxygen: list(markdown = TRUE)
-Suggests:
-    callr,
-    covr,
-    mockery,
-    testthat
 Imports:
     cli,
     tools,
     utils,
     withr
+Suggests:
+    callr,
+    covr,
+    mockery,
+    testthat
 Encoding: UTF-8
+LazyData: true
+Roxygen: list(markdown = TRUE)
+RoxygenNote: 6.1.0


### PR DESCRIPTION
Same reasoning as with rcmdcheck. I made all the specific humans `aut` and used `ctb` for R Core, so check me on that.