### PR TITLE
Support diffing session info's from GHA logs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -39,6 +39,7 @@ Imports:
 Suggests:
     callr,
     covr,
+    gh,
     mockery,
     reticulate,
     rmarkdown,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,9 @@
 
 # development version
 
+* `session_diff()` now accepts the URL to a GitHub Actions log as the source for
+  `new` and/or `old` (@jennybc, #68).
+
 # 1.2.2
 
 * This version does not add an emoji hash to the output.

--- a/R/compare.R
+++ b/R/compare.R
@@ -22,7 +22,7 @@
 #' * Any other URL starting with `http://` or `https://`. `session_diff()`
 #'   searches the HTML (or text) page for the session info header to find the
 #'   session info.
-#'   session info.
+#'
 #'
 #' @export
 #' @examplesIf FALSE

--- a/R/compare.R
+++ b/R/compare.R
@@ -14,9 +14,15 @@
 #' * `"clipboard"` takes the session info from the system clipboard.
 #'   If the clipboard contains a URL, it is followed to download the
 #'   session info.
-#' * A URL starting with `http://` or `https://`. `session_diff` searches
-#'   the HTML (or text) page for the session info header to find the session
-#'   info.
+#' * The URL where you inspect the results for a GitHub Actions job.
+#'   Typically has this form:
+#'   ```
+#'   https://github.com/OWNER/REPO/runs/JOB_ID?check_suite_focus=true
+#'   ```
+#' * Any other URL starting with `http://` or `https://`. `session_diff()`
+#'   searches the HTML (or text) page for the session info header to find the
+#'   session info.
+#'   session info.
 #'
 #' @export
 #' @examplesIf FALSE

--- a/R/compare.R
+++ b/R/compare.R
@@ -61,6 +61,8 @@ get_session_info <- function(src, name = NULL, ...) {
     get_session_info_local(...)
   } else if (is_string(src) == 1 && src == "clipboard") {
     get_session_info_clipboard()
+  } else if (is_string(src) && is_gha_url(src)) {
+    get_session_info_gha(src)
   } else if (is_string(src) && grepl("https?://", src)) {
     get_session_info_url(src)
   } else {

--- a/R/github-actions.R
+++ b/R/github-actions.R
@@ -39,12 +39,12 @@ is_gha_url <- function(url) {
 
 get_session_info_gha <- function(url) {
   if (!requireNamespace("gh", quietly = TRUE)) {
-    cli::cli_abort(c(
-      "The gh package is not available.",
-      "i" = "This appears to be the URL for a GitHub Actions (GHA) log:",
-      " " = "{.url {url}}",
-      "x" = "The {.pkg gh} package is required to get session info for GHA jobs."
-    ))
+    stop(
+      "The gh package is not available.\n",
+      "This appears to be the URL for a GitHub Actions (GHA) log:\n",
+      url, "\n",
+      "You must install the gh package to get session info for GHA job logs."
+    )
   }
 
   dat <- parse_as_gha_url(url)

--- a/R/github-actions.R
+++ b/R/github-actions.R
@@ -57,7 +57,7 @@ get_session_info_gha <- function(url) {
     owner = dat$owner, repo = dat$repo, job_id = dat$job_id
   )
   timestamped_lines <- unlist(strsplit(raw_log$message, split = "\r\n"))
-  lines <- sub("^.+Z ", "", timestamped_lines)
+  lines <- sub("^[^\\s]+\\s+", "", timestamped_lines, perl = TRUE)
   start_pos <- grep("##[group]Session info", lines, fixed = TRUE)
   endgroups <- grep("##[endgroup]", lines, fixed = TRUE)
   end_pos <- min(endgroups[endgroups > start_pos])

--- a/man/session_diff.Rd
+++ b/man/session_diff.Rd
@@ -25,9 +25,13 @@ session, and uses its output.
 \item \code{"clipboard"} takes the session info from the system clipboard.
 If the clipboard contains a URL, it is followed to download the
 session info.
-\item A URL starting with \verb{http://} or \verb{https://}. \code{session_diff} searches
-the HTML (or text) page for the session info header to find the session
-info.
+\item The URL where you inspect the results for a GitHub Actions job.
+Typically has this form:\preformatted{https://github.com/OWNER/REPO/runs/JOB_ID?check_suite_focus=true
+}
+\item Any other URL starting with \verb{http://} or \verb{https://}. \code{session_diff()}
+searches the HTML (or text) page for the session info header to find the
+session info.
+session info.
 }
 }
 \examples{

--- a/man/session_diff.Rd
+++ b/man/session_diff.Rd
@@ -31,7 +31,6 @@ Typically has this form:\preformatted{https://github.com/OWNER/REPO/runs/JOB_ID?
 \item Any other URL starting with \verb{http://} or \verb{https://}. \code{session_diff()}
 searches the HTML (or text) page for the session info header to find the
 session info.
-session info.
 }
 }
 \examples{


### PR DESCRIPTION
Add support to `session_diff()` for `new` and `old` to be URLs that link to a GitHub Actions job.

Currently session diff works best when comparing sessions for two jobs of the same "flavour", because you don't pick up differences in package source. This has nothing to do with GHA, but is something I've really noticed while working on this, because I do really want to do cross-flavour comparisons. I have another idea for that which is proposed in #69.

Here it is in action, comparing two adjacent GHA runs for readr, both on ubuntu-18.04 (release), showing that the differences in the library are magrittr and rlang.

``` r
devtools::load_all()
#> ℹ Loading sessioninfo
session_diff(
  # a successful GHA run
  "https://github.com/tidyverse/readr/runs/4971816401?check_suite_focus=true",
  # the next GHA run, which failed ... WHY?
  "https://github.com/tidyverse/readr/runs/4976911977?check_suite_focus=true",
)
#> --- ubuntu-18.04 (release) | success | job 4971816401 | run 1758177206
#> +++ ubuntu-18.04 (release) | failure | job 4976911977 | run 1760148193
#>  ─ Session info ───────────────────────────────────────────────────────────────
#>   setting  value
#>   version  R version 4.1.2 (2021-11-01)
#>   os       Ubuntu 18.04.6 LTS
#>   system   x86_64, linux-gnu
#>   ui       X11
#>   language (EN)
#>   collate  C.UTF-8
#>   ctype    C.UTF-8
#>   tz       UTC
#>   pandoc   2.14.2 @ /usr/bin/pandoc
#>  
#>  ─ Packages ───────────────────────────────────────────────────────────────────
#>   package     * version    date (UTC) lib source
#>   askpass       1.1        2019-01-13 [1] RSPM
#>   base        * 4.1.2      2022-01-04 [2] local
#>   base64enc     0.1-3      2015-07-28 [1] RSPM
#>   bit           4.0.4      2020-08-04 [1] RSPM
#>   bit64         4.0.5      2020-08-30 [1] RSPM
#>   boot          1.3-28     2021-05-03 [2] CRAN (R 4.1.2)
#>   brio          1.1.3      2021-11-30 [1] RSPM
#>   callr         3.7.0      2021-04-20 [1] RSPM
#>   class         7.3-19     2021-05-03 [2] CRAN (R 4.1.2)
#>   cli           3.1.1      2022-01-20 [1] RSPM
#>   clipr         0.7.1      2020-10-08 [1] RSPM
#>   cluster       2.1.2      2021-04-17 [2] CRAN (R 4.1.2)
#>   codetools     0.2-18     2020-11-04 [2] CRAN (R 4.1.2)
#>   commonmark    1.7        2018-12-01 [1] RSPM
#>   compiler      4.1.2      2022-01-04 [2] local
#>   covr          3.5.1      2020-09-16 [1] RSPM
#>   cpp11         0.4.2      2021-11-30 [1] RSPM
#>   crayon        1.4.2      2021-10-29 [1] RSPM
#>   curl          4.3.2      2021-06-23 [1] RSPM
#>   datasets    * 4.1.2      2022-01-04 [2] local
#>   desc          1.4.0      2021-09-28 [1] RSPM
#>   diffobj       0.3.5      2021-10-05 [1] RSPM
#>   digest        0.6.29     2021-12-01 [1] RSPM
#>   ellipsis      0.3.2      2021-04-29 [1] RSPM
#>   evaluate      0.14       2019-05-28 [1] RSPM
#>   fansi         1.0.2      2022-01-14 [1] RSPM
#>   fastmap       1.1.0      2021-01-25 [1] RSPM
#>   foreign       0.8-81     2020-12-22 [2] CRAN (R 4.1.2)
#>   glue          1.6.1      2022-01-22 [1] RSPM
#>   graphics    * 4.1.2      2022-01-04 [2] local
#>   grDevices   * 4.1.2      2022-01-04 [2] local
#>   grid          4.1.2      2022-01-04 [2] local
#>   highr         0.9        2021-04-16 [1] RSPM
#>   hms           1.1.1      2021-09-26 [1] RSPM
#>   htmltools     0.5.2      2021-08-25 [1] RSPM
#>   httr          1.4.2      2020-07-20 [1] RSPM
#>   hunspell      3.0.1      2020-12-09 [1] RSPM
#>   jquerylib     0.1.4      2021-04-26 [1] RSPM
#>   jsonlite      1.7.3      2022-01-17 [1] RSPM
#>   KernSmooth    2.23-20    2021-05-03 [2] CRAN (R 4.1.2)
#>   knitr         1.37       2021-12-16 [1] RSPM
#>   lattice       0.20-45    2021-09-22 [2] CRAN (R 4.1.2)
#>   lazyeval      0.2.2      2019-03-15 [1] RSPM
#>   lifecycle     1.0.1      2021-09-24 [1] RSPM
#> - magrittr      2.0.1      2020-11-17 [1] RSPM
#> + magrittr      2.0.2      2022-01-26 [1] RSPM
#>   MASS          7.3-54     2021-05-03 [2] CRAN (R 4.1.2)
#>   Matrix        1.3-4      2021-06-01 [2] CRAN (R 4.1.2)
#>   methods     * 4.1.2      2022-01-04 [2] local
#>   mgcv          1.8-38     2021-10-06 [2] CRAN (R 4.1.2)
#>   mime          0.12       2021-09-28 [1] RSPM
#>   nlme          3.1-153    2021-09-07 [2] CRAN (R 4.1.2)
#>   nnet          7.3-16     2021-05-03 [2] CRAN (R 4.1.2)
#>   openssl       1.4.6      2021-12-19 [1] RSPM
#>   pak           0.2.0.9000 2022-01-27 [1] local
#>   parallel      4.1.2      2022-01-04 [2] local
#>   pillar        1.6.5      2022-01-25 [1] RSPM
#>   pkgbuild      1.3.1      2021-12-20 [1] RSPM
#>   pkgconfig     2.0.3      2019-09-22 [1] RSPM
#>   pkgload       1.2.4      2021-11-30 [1] RSPM
#>   praise        1.0.0      2015-08-11 [1] RSPM
#>   prettyunits   1.1.1      2020-01-24 [1] RSPM
#>   processx      3.5.2      2021-04-30 [1] RSPM
#>   progress      1.2.2      2019-05-16 [1] RSPM
#>   ps            1.6.0      2021-02-28 [1] RSPM
#>   purrr         0.3.4      2020-04-17 [1] RSPM
#>   R6            2.5.1      2021-08-19 [1] RSPM
#>   rcmdcheck     1.4.0      2021-09-27 [1] any (@1.4.0)
#>   Rcpp          1.0.8      2022-01-13 [1] RSPM
#>   rematch2      2.1.2      2020-05-01 [1] RSPM
#>   rex           1.2.1      2021-11-26 [1] RSPM
#> - rlang         0.4.12     2021-10-18 [1] RSPM
#> + rlang         1.0.0      2022-01-26 [1] RSPM
#>   rmarkdown     2.11       2021-09-14 [1] RSPM
#>   rpart         4.1-15     2019-04-12 [2] CRAN (R 4.1.2)
#>   rprojroot     2.0.2      2020-11-15 [1] RSPM
#>   rstudioapi    0.13       2020-11-12 [1] RSPM
#>   sessioninfo   1.2.2      2021-12-06 [1] any (@1.2.2)
#>   spatial       7.3-14     2021-05-03 [2] CRAN (R 4.1.2)
#>   spelling      2.2        2020-10-18 [1] RSPM
#>   splines       4.1.2      2022-01-04 [2] local
#>   stats       * 4.1.2      2022-01-04 [2] local
#>   stats4        4.1.2      2022-01-04 [2] local
#>   stringi       1.7.6      2021-11-29 [1] RSPM
#>   stringr       1.4.0      2019-02-10 [1] RSPM
#>   survival      3.2-13     2021-08-24 [2] CRAN (R 4.1.2)
#>   sys           3.4        2020-07-23 [1] RSPM
#>   tcltk         4.1.2      2022-01-04 [2] local
#>   testthat      3.1.2      2022-01-20 [1] RSPM
#>   tibble        3.1.6      2021-11-07 [1] RSPM
#>   tidyselect    1.1.1      2021-04-30 [1] RSPM
#>   tinytex       0.36       2021-12-19 [1] RSPM
#>   tools         4.1.2      2022-01-04 [2] local
#>   tzdb          0.2.0      2021-10-27 [1] RSPM
#>   utf8          1.2.2      2021-07-24 [1] RSPM
#>   utils       * 4.1.2      2022-01-04 [2] local
#>   vctrs         0.3.8      2021-04-29 [1] RSPM
#>   vroom         1.5.7      2021-11-30 [1] RSPM
#>   waldo         0.3.1      2021-09-14 [1] RSPM
#>   withr         2.4.3      2021-11-30 [1] RSPM
#>   xfun          0.29       2021-12-14 [1] RSPM
#>   xml2          1.3.3      2021-11-30 [1] RSPM
#>   xopen         1.0.0      2018-09-17 [1] RSPM
#>   yaml          2.2.2      2022-01-25 [1] RSPM
#>  
#>   [1] /home/runner/work/_temp/Library
#>   [2] /opt/R/4.1.2/lib/R/library
#>  
#>  ──────────────────────────────────────────────────────────────────────────────
```

<sup>Created on 2022-01-29 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1.9000)</sup>