### PR TITLE
Use a join, instead of line diff, to compare package info

### DIFF
--- a/R/compare.R
+++ b/R/compare.R
@@ -4,6 +4,10 @@
 #' @param old,new A `session_info` object (the return value of
 #' [session_info()]), or a pointer to [session_info()] output. See details
 #' below.
+#' @param packages How to compare the package info for `old` and `new`:
+#' * `"diff"`: line diffs, in the style of `diff -u`
+#' * `"merge"`: merge the information into one data frame, with one row per
+#'   package. Only package `version` and `source` are compared.
 #' @param ... Passed to any new [session_info()] calls.
 #'
 #' @details

--- a/R/github-actions.R
+++ b/R/github-actions.R
@@ -82,7 +82,7 @@ get_session_info_gha <- function(url) {
     owner = dat$owner, repo = dat$repo, job_id = dat$job_id
   )
   timestamped_lines <- unlist(strsplit(raw_log$message, split = "\r\n|\n"))
-  lines <- sub("^[^\\s]+\\s+", "", timestamped_lines, perl = TRUE)
+  lines <- sub("^[^\\s]+\\s", "", timestamped_lines, perl = TRUE)
 
   re_start <- "[-=\u2500\u2550][ ]Session info[ ]"
   cand <- grep(re_start, lines)

--- a/man/session_diff.Rd
+++ b/man/session_diff.Rd
@@ -4,12 +4,24 @@
 \alias{session_diff}
 \title{Compare session information from two sources}
 \usage{
-session_diff(old = "local", new = "clipboard", ...)
+session_diff(
+  old = "local",
+  new = "clipboard",
+  packages = c("diff", "merge"),
+  ...
+)
 }
 \arguments{
 \item{old, new}{A \code{session_info} object (the return value of
 \code{\link[=session_info]{session_info()}}), or a pointer to \code{\link[=session_info]{session_info()}} output. See details
 below.}
+
+\item{packages}{How to compare the package info for \code{old} and \code{new}:
+\itemize{
+\item \code{"diff"}: line diffs, in the style of \code{diff -u}
+\item \code{"merge"}: merge the information into one data frame, with one row per
+package. Only package \code{version} and \code{source} are compared.
+}}
 
 \item{...}{Passed to any new \code{\link[=session_info]{session_info()}} calls.}
 }


### PR DESCRIPTION
Comparing two session info's via plain line diff often results in a long run of lines from `new`, followed by a long run of lines from `old`, which makes it hard to compare package versions from `new` to `old`.

The problem is exacerbated when comparing across two OSes, because `source` frequently differs (e.g. macOS & CRAN vs ubuntu & RSPM).

In the worst case scenario, which happens quite often: you get the whole `new` package listing, then the whole `old` listing. Which is basically what the inputs were.

This PR uses a full join of package info, instead of line diffs, to juxtapose `new` and `old`. This results in one row per package, with unequal version or source flagged with `>>`. It's a little hack-y, but it's the best I can do without a larger refactoring and it feels really useful to me already.

This is just an MVP but I'd be happy to make it more robust / tested, if it could be merged.

*Some before and after examples to follow.*



