### PR TITLE
Only trim a single space when removing the timestamp

### DIFF
--- a/R/github-actions.R
+++ b/R/github-actions.R
@@ -57,7 +57,7 @@ get_session_info_gha <- function(url) {
     owner = dat$owner, repo = dat$repo, job_id = dat$job_id
   )
   timestamped_lines <- unlist(strsplit(raw_log$message, split = "\r\n"))
-  lines <- sub("^[^\\s]+\\s+", "", timestamped_lines, perl = TRUE)
+  lines <- sub("^[^\\s]+\\s", "", timestamped_lines, perl = TRUE)
 
   re_start <- "[-=\u2500\u2550][ ]Session info[ ]"
   cand <- grep(re_start, lines)


### PR DESCRIPTION
This is a refinement to the extraction of session info from GHA logs (#68).

My previous timestamp-removing regex was too aggressive with whitespace removal, which causes more-than-necessary line diffs when comparing to local session info. This was not noticeable when comparing GHA to GHA, which was my original motivation.

(This *might* help with what @njtierney showed in https://github.com/r-lib/sessioninfo/pull/69#issuecomment-1055058002, but I haven't been able to replicate that, so it's hard to say. That looks like a difference relating to presence / absence of the `!` column.)