### PR TITLE
Update pkgdown

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -20,7 +20,7 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: r-lib/actions/setup-pandoc@v2
 
@@ -32,7 +32,6 @@ jobs:
         with:
           extra-packages: any::pkgdown, local::.
           needs: website
-          pak-version: rc
 
       - name: Build site
         run: pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE)
@@ -40,7 +39,7 @@ jobs:
 
       - name: Deploy to GitHub pages 🚀
         if: github.event_name != 'pull_request'
-        uses: JamesIves/github-pages-deploy-action@4.1.4
+        uses: JamesIves/github-pages-deploy-action@v4.4.1
         with:
           clean: false
           branch: gh-pages

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,7 +17,7 @@ Description: Query and print information about the current R session.  It
     about packages, and where they were installed from.
 License: GPL-2
 URL: https://github.com/r-lib/sessioninfo#readme,
-    https://r-lib.github.io/sessioninfo/
+    https://sessioninfo.r-lib.org
 BugReports: https://github.com/r-lib/sessioninfo/issues
 Depends: 
     R (>= 3.4)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,10 +1,11 @@
 
-# development version
+# sessioninfo (development version)
 
+* update pkgdown url to sessioninfo.r-lib.org
 * `session_diff()` now accepts the URL to a GitHub Actions log as the source for
   `new` and/or `old` (@jennybc, #68).
 
-# 1.2.2
+# sessioninfo 1.2.2
 
 * This version does not add an emoji hash to the output.
 
@@ -19,7 +20,7 @@
   now shown in the `source` column, if they set the `Repository`
   field in `DESCRIPTION`.
 
-# 1.2.1
+# sessioninfo 1.2.1
 
 * `package_info()` and `session_info()` now do not fail if the version
   number of an installed package is invalid.
@@ -27,7 +28,7 @@
 * Better aliases for the list of attached, loaded and installed packages
   in `package_inf()` and `session_info()`.
 
-# 1.2.0
+# sessioninfo 1.2.0
 
 * New function `external_info()`, information about external software.
   It can be also requested with the new `info` argument of
@@ -73,7 +74,7 @@
 
 * The `source` column of the package list is now more informative.
 
-# 1.1.1
+# sessioninfo 1.1.1
 
 * `package_info()` and `session_info()` now detect locally installed packages 
   correctly if they have an empty `biocViews` field in `DESCRIPTION (@llrs, #25)
@@ -81,7 +82,7 @@
 * `package_info()` and `session_info()` now handle the case when a loaded
   package was removed from the disk.
 
-# 1.1.0
+# sessioninfo 1.1.0
 
 * `package_info()` now has a `dependencies` argument, to filter the type
   of dependent packages in the output (#22).
@@ -116,6 +117,6 @@
 * Do not consult the `max.print` option, for platform and package info
   (@jennybc, #13).
 
-# 1.0.0
+# sessioninfo 1.0.0
 
 First public release.

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,4 +1,4 @@
-url: https://r-lib.github.io/sessioninfo
+url: https://sessioninfo.r-lib.org
 
 template:
   package: tidytemplate
@@ -6,7 +6,7 @@ template:
 
   includes:
     in_header: |
-      <script defer data-domain="r-lib.github.io/sessioninfo,all.tidyverse.org" src="https://plausible.io/js/plausible.js"></script>
+      <script defer data-domain="sessioninfo.r-lib.org,all.tidyverse.org" src="https://plausible.io/js/plausible.js"></script>
 
 destination: docs
 

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -13,17 +13,6 @@ destination: docs
 development:
   mode: auto
 
-navbar:
-  type: default
-  left:
-  # TODO: uncomment once this vignette is added
-  #- text: Intro
-  #  href: articles/introduction.html
-  - text: Reference
-    href: reference/index.html
-  - text: News
-    href: news/index.html
-
 reference:
 - title: Session information
   contents:


### PR DESCRIPTION
Following the checklist at [tidytemplate](https://github.com/tidyverse/tidytemplate#updating)

* [x] `usethis::use_pkgdown_github_pages()`
* [x] Ensure Author includes RStudio as copyright holder and funder
* [x] Update `DESCRIPTION` to include `Config/Needs/website: tidyverse/tidytemplate`
* [x] Update `_pkgdown.yml` with appropriate template above.
* [x] Ping Hadley to add plausible.io record
* [ ] ~Remove `strip_header: true`~
* [ ] ~Remove algolia search, if used~
* [x] Eliminate superseded navbar customisation (`home: ~`, article re-ordering)
* [x] Update `news` structure if needed
* [ ] ~Remove any author info for tidyverse folks (since now included in template)~

CNAME record not obtained yet - I will update the custom domain in settings (to pkgbuild.r-lib.org) once we have the CNAME and this is merged