### PR TITLE
Update GHA log parsing to reflect current URL structure

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -41,4 +41,4 @@ Config/testthat/edition: 3
 Config/testthat/parallel: true
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.2.9000
+RoxygenNote: 7.2.3

--- a/R/compare.R
+++ b/R/compare.R
@@ -17,8 +17,10 @@
 #' * The URL where you inspect the results for a GitHub Actions job.
 #'   Typically has this form:
 #'   ```
-#'   https://github.com/OWNER/REPO/runs/JOB_ID?check_suite_focus=true
+#'   https://github.com/OWNER/REPO/actions/runs/RUN_ID/jobs/HTML_ID
 #'   ```
+#'   Internally, this URL is parsed so we can look up the job id, get the
+#'   log file, and extract session info.
 #' * Any other URL starting with `http://` or `https://`. `session_diff()`
 #'   searches the HTML (or text) page for the session info header to find the
 #'   session info.

--- a/R/github-actions.R
+++ b/R/github-actions.R
@@ -16,17 +16,29 @@ github_url_regex <- paste0(
   "$"
 )
 
+github_fragment_regex <- paste0(
+  "/runs/",
+  "(?<run_id>[0-9]+)",
+  "/jobs/",
+  "(?<html_id>[0-9]+)",
+  "$"
+)
+
 parse_as_gha_url <- function(url) {
   res <- re_match(url, github_url_regex)$groups
-  res$job_id <- re_match(res$fragment, "^/runs/(?<job_id>[0-9]+).*")$groups$job_id
+  res2 <- re_match(res$fragment, github_fragment_regex)$groups
+  res$run_id <- res2$run_id
+  res$html_id <- res2$html_id
 
   ok <- res$host %in% "github.com" &
-    !is.na(res$repo_owner) & !is.na(res$repo_name) &!is.na(res$job_id)
+    !is.na(res$repo_owner) & !is.na(res$repo_name) &
+    !is.na(res$run_id) & !is.na(res$html_id)
 
   data.frame(
     owner  = ifelse(ok, res$repo_owner, NA_character_),
     repo   = ifelse(ok, res$repo_name, NA_character_),
-    job_id = ifelse(ok, res$job_id, NA_character_),
+    run_id = ifelse(ok, res$run_id, NA_character_),
+    html_id = ifelse(ok, res$html_id, NA_character_),
     stringsAsFactors = FALSE,
     row.names = NULL
   )
@@ -34,7 +46,7 @@ parse_as_gha_url <- function(url) {
 
 is_gha_url <- function(url) {
   res <- parse_as_gha_url(url)
-  !is.na(res$job_id)
+  !is.na(res$run_id)
 }
 
 get_session_info_gha <- function(url) {
@@ -48,6 +60,16 @@ get_session_info_gha <- function(url) {
   }
 
   dat <- parse_as_gha_url(url)
+  # the last ID in the browser URL is not the job_id!
+  # instead, we must lookup the job_id
+  jobs <- gh::gh(
+    "/repos/{owner}/{repo}/actions/runs/{run_id}/jobs",
+    owner = dat$owner, repo = dat$repo, run_id = dat$run_id
+  )
+  html_urls <- lapply(jobs[["jobs"]], function(x) x[["html_url"]])
+  i <- which(html_urls == url)
+  dat$job_id <- jobs[["jobs"]][[i]][["id"]]
+
   meta <- gh::gh(
     "/repos/{owner}/{repo}/actions/jobs/{job_id}",
     owner = dat$owner, repo = dat$repo, job_id = dat$job_id

--- a/man/session_diff.Rd
+++ b/man/session_diff.Rd
@@ -26,8 +26,13 @@ session, and uses its output.
 If the clipboard contains a URL, it is followed to download the
 session info.
 \item The URL where you inspect the results for a GitHub Actions job.
-Typically has this form:\preformatted{https://github.com/OWNER/REPO/runs/JOB_ID?check_suite_focus=true
-}
+Typically has this form:
+
+\if{html}{\out{<div class="sourceCode">}}\preformatted{https://github.com/OWNER/REPO/actions/runs/RUN_ID/jobs/HTML_ID
+}\if{html}{\out{</div>}}
+
+Internally, this URL is parsed so we can look up the job id, get the
+log file, and extract session info.
 \item Any other URL starting with \verb{http://} or \verb{https://}. \code{session_diff()}
 searches the HTML (or text) page for the session info header to find the
 session info.

--- a/man/sessioninfo-package.Rd
+++ b/man/sessioninfo-package.Rd
@@ -12,7 +12,7 @@ Query and print information about the current R session. It is similar to 'utils
 Useful links:
 \itemize{
   \item \url{https://github.com/r-lib/sessioninfo#readme}
-  \item \url{https://r-lib.github.io/sessioninfo/}
+  \item \url{https://sessioninfo.r-lib.org}
   \item Report bugs at \url{https://github.com/r-lib/sessioninfo/issues}
 }
 
@@ -32,6 +32,7 @@ Authors:
 Other contributors:
 \itemize{
   \item R Core team [contributor]
+  \item Posit Software, PBC [copyright holder, funder]
 }
 
 }


### PR DESCRIPTION
Sadly, the structure of the GHA browser URLs has changed since we first started to support sessiondiff-ing GHA logs (#68).

In particular, the **job id** no longer appears in the browser URL. We can recover the **run id** from this URL, get the associated jobs, find the one whose `html_url` matches the input, then lookup the job id 😬 

With this PR, I am back in business for sessiondiff-ing GHA runs. Below is an example where I learn that pillar, probably, is making snapshot tests fail in googledrive.

---

``` r
session_diff(
  "https://github.com/tidyverse/googledrive/actions/runs/4492158344/jobs/7901651969",
  "https://github.com/tidyverse/googledrive/actions/runs/4493316123/jobs/7904370304"
)
#> Warning in runs$length: partial match of 'length' to 'lengths'
#> --- windows-latest (4.1) | success | job 12197933120 | run 4492158344
#> +++ windows-latest (4.1) | failure | job 12201564206 | run 4493316123
#>  ─ Session info ───────────────────────────────────────────────────────────────
#>  setting  value
#>  version  R version 4.1.3 (2022-03-10)
#>  os       Windows Server x64 (build 20348)
#>  system   x86_64, mingw32
#>  ui       RTerm
#>  language (EN)
#>  collate  English_United States.1252
#>  ctype    English_United States.1252
#>  tz       UTC
#>  pandoc   2.19.2 @ C:\\HOSTED~1\\windows\\pandoc\\219~1.2\\x64\\PANDOC~1.2\\pandoc.exe
#>  
#>  ─ Packages ───────────────────────────────────────────────────────────────────
#>   package      * version date (UTC) lib source
#>   askpass        1.1     2019-01-13 [1] RSPM
#>   base         * 4.1.3   2022-03-10 [3] local
#>   base64enc      0.1-3   2015-07-28 [1] RSPM
#>   boot           1.3-28  2021-05-03 [3] CRAN (R 4.1.3)
#>   brew           1.0-8   2022-09-29 [1] RSPM
#>   brio           1.1.3   2021-11-30 [1] RSPM
#>   bslib          0.4.2   2022-12-16 [1] RSPM
#>   cachem         1.0.7   2023-02-24 [1] RSPM
#>   callr          3.7.3   2022-11-02 [1] RSPM
#>   class          7.3-20  2022-01-16 [3] CRAN (R 4.1.3)
#>   cli            3.6.0   2023-01-09 [1] RSPM
#>   cluster        2.1.2   2021-04-17 [3] CRAN (R 4.1.3)
#>   codetools      0.2-18  2020-11-04 [3] CRAN (R 4.1.3)
#>   commonmark     1.9.0   2023-03-17 [1] RSPM
#>   compiler       4.1.3   2022-03-10 [3] local
#>   covr           3.6.1   2022-08-26 [1] RSPM
#>   crayon         1.5.2   2022-09-29 [1] RSPM
#>   curl           5.0.0   2023-01-12 [1] RSPM
#>   datasets     * 4.1.3   2022-03-10 [3] local
#>   desc           1.4.2   2022-09-08 [1] RSPM
#>   diffobj        0.3.5   2021-10-05 [1] RSPM
#>   digest         0.6.31  2022-12-11 [1] RSPM
#>   downlit        0.4.2   2022-07-05 [1] RSPM
#>   dplyr          1.1.0   2023-01-29 [1] RSPM
#>   ellipsis       0.3.2   2021-04-29 [1] RSPM
#>   evaluate       0.20    2023-01-17 [1] RSPM
#>   fansi          1.0.4   2023-01-22 [1] RSPM
#>   fastmap        1.1.1   2023-02-24 [1] RSPM
#>   foreign        0.8-82  2022-01-16 [3] CRAN (R 4.1.3)
#>   fs             1.6.1   2023-02-06 [1] RSPM
#>   gargle         1.3.0   2023-01-30 [1] RSPM
#>   generics       0.1.3   2022-07-05 [1] RSPM
#>   glue           1.6.2   2022-02-24 [1] RSPM
#>   graphics     * 4.1.3   2022-03-10 [3] local
#>   grDevices    * 4.1.3   2022-03-10 [3] local
#>   grid           4.1.3   2022-03-10 [3] local
#>   highr          0.10    2022-12-22 [1] RSPM
#>   htmltools      0.5.4   2022-12-07 [1] RSPM
#>   httr           1.4.5   2023-02-24 [1] RSPM
#>   hunspell       3.0.2   2022-09-04 [1] RSPM
#>   jquerylib      0.1.4   2021-04-26 [1] RSPM
#>   jsonlite       1.8.4   2022-12-06 [1] RSPM
#>   KernSmooth     2.23-20 2021-05-03 [3] CRAN (R 4.1.3)
#>   knitr          1.42    2023-01-25 [1] RSPM
#>   lattice        0.20-45 2021-09-22 [3] CRAN (R 4.1.3)
#>   lazyeval       0.2.2   2019-03-15 [1] RSPM
#>   lifecycle      1.0.3   2022-10-07 [1] RSPM
#>   magrittr       2.0.3   2022-03-30 [1] RSPM
#>   MASS           7.3-55  2022-01-16 [3] CRAN (R 4.1.3)
#>   Matrix         1.4-0   2021-12-08 [3] CRAN (R 4.1.3)
#>   memoise        2.0.1   2021-11-26 [1] RSPM
#>   methods      * 4.1.3   2022-03-10 [3] local
#>   mgcv           1.8-39  2022-02-24 [3] CRAN (R 4.1.3)
#>   mime           0.12    2021-09-28 [1] RSPM
#>   mockr          0.2.1   2023-02-01 [1] RSPM
#>   nlme           3.1-155 2022-01-16 [3] CRAN (R 4.1.3)
#>   nnet           7.3-17  2022-01-16 [3] CRAN (R 4.1.3)
#>   openssl        2.0.6   2023-03-09 [1] RSPM
#>   pak            0.4.0   2023-01-16 [2] local
#>   parallel       4.1.3   2022-03-10 [3] local
#> - pillar         1.8.1   2022-08-19 [1] RSPM
#> + pillar         1.9.0   2023-03-22 [1] CRAN (R 4.1.3)
#>   pkgbuild       1.4.0   2022-11-27 [1] RSPM
#>   pkgconfig      2.0.3   2019-09-22 [1] RSPM
#>   pkgload        1.3.2   2022-11-16 [1] RSPM
#>   praise         1.0.0   2015-08-11 [1] RSPM
#>   prettyunits    1.1.1   2020-01-24 [1] RSPM
#>   processx       3.8.0   2022-10-26 [1] RSPM
#>   ps             1.7.3   2023-03-21 [1] RSPM
#>   purrr          1.0.1   2023-01-10 [1] RSPM
#>   R6             2.5.1   2021-08-19 [1] RSPM
#>   rappdirs       0.3.3   2021-01-31 [1] RSPM
#>   rcmdcheck      1.4.0   2021-09-27 [1] any (@1.4.0)
#>   Rcpp           1.0.10  2023-01-22 [1] RSPM
#>   rematch2       2.1.2   2020-05-01 [1] RSPM
#>   rex            1.2.1   2021-11-26 [1] RSPM
#>   rlang          1.1.0   2023-03-14 [1] RSPM
#>   rmarkdown      2.20    2023-01-19 [1] RSPM
#>   roxygen2       7.2.3   2022-12-08 [1] RSPM
#>   rpart          4.1.16  2022-01-24 [3] CRAN (R 4.1.3)
#>   rprojroot      2.0.3   2022-04-02 [1] RSPM
#>   rstudioapi     0.14    2022-08-22 [1] RSPM
#>   sass           0.4.5   2023-01-24 [1] RSPM
#>   sessioninfo    1.2.2   2021-12-06 [1] any (@1.2.2)
#>   sodium         1.2.1   2022-06-11 [1] RSPM
#>   spatial        7.3-15  2022-01-16 [3] CRAN (R 4.1.3)
#> - spelling       2.2     2020-10-18 [1] RSPM
#> + spelling       2.2.1   2023-03-22 [1] CRAN (R 4.1.3)
#>   splines        4.1.3   2022-03-10 [3] local
#>   stats        * 4.1.3   2022-03-10 [3] local
#>   stats4         4.1.3   2022-03-10 [3] local
#>   stringi        1.7.12  2023-01-11 [1] RSPM
#>   stringr        1.5.0   2022-12-02 [1] RSPM
#>   survival       3.2-13  2021-08-24 [3] CRAN (R 4.1.3)
#>   sys            3.4.1   2022-10-18 [1] RSPM
#>   tcltk          4.1.3   2022-03-10 [3] local
#>   testthat       3.1.7   2023-03-12 [1] RSPM
#>   tibble         3.2.1   2023-03-20 [1] RSPM
#>   tidyselect     1.2.0   2022-10-10 [1] RSPM
#>   tinytex        0.44    2023-02-01 [1] RSPM
#>   tools          4.1.3   2022-03-10 [3] local
#>   translations   4.1.3   2022-03-10 [3] local
#>   utf8           1.2.3   2023-01-31 [1] RSPM
#>   utils        * 4.1.3   2022-03-10 [3] local
#>   uuid           1.1-0   2022-04-19 [1] RSPM
#>   vctrs          0.6.0   2023-03-16 [1] RSPM
#>   waldo          0.4.0   2022-03-16 [1] RSPM
#>   withr          2.5.0   2022-03-03 [1] RSPM
#>   xfun           0.37    2023-01-31 [1] RSPM
#>   xml2           1.3.3   2021-11-30 [1] RSPM
#>   xopen          1.0.0   2018-09-17 [1] RSPM
#>   yaml           2.3.7   2023-01-23 [1] RSPM
#>  
#>  [1] D:/a/_temp/Library
#>  [2] C:/R/site-library
#>  [3] C:/R/library
```
