### PR TITLE
More tweaks re: extracting session info from GHA logs

### DIFF
--- a/R/github-actions.R
+++ b/R/github-actions.R
@@ -68,6 +68,9 @@ get_session_info_gha <- function(url) {
   )
   html_urls <- vapply(jobs[["jobs"]], function(x) x[["html_url"]], "")
   i <- which(html_urls == url)
+  if (length(i) == 0) {
+    stop("Failed to find the job associated with '", url, "'; perhaps there was a later attempt?")
+  }
   dat$job_id <- jobs[["jobs"]][[i]][["id"]]
 
   meta <- gh::gh(
@@ -78,7 +81,7 @@ get_session_info_gha <- function(url) {
     "/repos/{owner}/{repo}/actions/jobs/{job_id}/logs",
     owner = dat$owner, repo = dat$repo, job_id = dat$job_id
   )
-  timestamped_lines <- unlist(strsplit(raw_log$message, split = "\r\n"))
+  timestamped_lines <- unlist(strsplit(raw_log$message, split = "\r\n|\n"))
   lines <- sub("^[^\\s]+\\s+", "", timestamped_lines, perl = TRUE)
 
   re_start <- "[-=\u2500\u2550][ ]Session info[ ]"


### PR DESCRIPTION
I've been sessiondiff'ing GHA logs again, which lead to the discovery that something about line breaks has changed. Unclear if that's on the GitHub end (probably) or us (less likely). That's why I want to split on `\r\n` or `\n`.

Then I also experienced what happens to these URLs when you re-run a failing job: the current strategy to get the log fails. That could be fixed because clearly there's a way to get logs from attempts other than the latest, but I don't think it's worth it. But we can at least throw a semi-decent error.