### PR TITLE
Add quarto version/path function to platform_info() - addresses #75

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,6 +32,7 @@ Suggests:
     mockery,
     reticulate,
     rmarkdown,
+    quarto,
     testthat,
     withr
 Config/Needs/website:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,7 +32,6 @@ Suggests:
     mockery,
     reticulate,
     rmarkdown,
-    quarto,
     testthat,
     withr
 Config/Needs/website:

--- a/R/platform-info.R
+++ b/R/platform-info.R
@@ -82,7 +82,7 @@ parse_pandoc_version <- function(path) {
 get_quarto_version <- function() {
   if (isNamespaceLoaded("quarto")) {
     path <- quarto::quarto_path()
-    ver <- system("quarto -V", intern = TRUE)
+    ver <- system("quarto -V", intern = TRUE)[1]
     if (is.null(path)) {
       "NA (via quarto)"
     } else {
@@ -93,7 +93,7 @@ get_quarto_version <- function() {
     if (path == "") {
       "NA"
     } else {
-      ver <- system("quarto -V", intern = TRUE)
+      ver <- system("quarto -V", intern = TRUE)[1]
       paste0(ver, " @ ", path)
     }
   }

--- a/R/platform-info.R
+++ b/R/platform-info.R
@@ -80,15 +80,6 @@ parse_pandoc_version <- function(path) {
 }
 
 get_quarto_version <- function() {
-  if (isNamespaceLoaded("quarto")) {
-    path <- quarto::quarto_path()
-    ver <- system("quarto -V", intern = TRUE)[1]
-    if (is.null(path)) {
-      "NA (via quarto)"
-    } else {
-      paste0(ver, " @ ", path, "/ (via quarto)")
-    }
-  } else {
     path <- Sys.which("quarto")
     if (path == "") {
       "NA"
@@ -97,7 +88,6 @@ get_quarto_version <- function() {
       paste0(ver, " @ ", path)
     }
   }
-}
 
 #' @export
 

--- a/R/platform-info.R
+++ b/R/platform-info.R
@@ -15,6 +15,7 @@
 #'   * `date`: The current date.
 #'   * `rstudio`: RStudio format string, only added in RStudio.
 #'   * `pandoc`: pandoc version and path
+#'   * `quarto`: quarto version and path
 #'
 #' @seealso Similar functions and objects in the base packages:
 #'   [base::R.version.string], [utils::sessionInfo()], [base::version],
@@ -36,7 +37,8 @@ platform_info <- function() {
     tz = Sys.timezone(),
     date = format(Sys.Date()),
     rstudio = get_rstudio_version(),
-    pandoc = get_pandoc_version()
+    pandoc = get_pandoc_version(),
+    quarto = get_quarto_version()
   )))
 }
 
@@ -75,6 +77,26 @@ parse_pandoc_version <- function(path) {
     out <- system2(path, "--version", stdout = TRUE)[1]
     last(strsplit(out, " ", fixed = TRUE)[[1]])
   }, error = function(e) "NA")
+}
+
+get_quarto_version <- function() {
+  if (isNamespaceLoaded("quarto")) {
+    path <- quarto::quarto_path()
+    ver <- system("quarto -V", intern = TRUE)
+    if (is.null(path)) {
+      "NA (via quarto)"
+    } else {
+      paste0(ver, " @ ", path, "/ (via quarto)")
+    }
+  } else {
+    path <- Sys.which("quarto")
+    if (path == "") {
+      "NA"
+    } else {
+      ver <- system("quarto -V", intern = TRUE)
+      paste0(ver, " @ ", path)
+    }
+  }
 }
 
 #' @export

--- a/tests/testthat/test-platform-info.R
+++ b/tests/testthat/test-platform-info.R
@@ -4,7 +4,7 @@ test_that("platform_info", {
   expect_equal(
     names(pi),
     c("version", "os", "system", "ui", "language", "collate", "ctype",
-      "tz", "date", "rstudio", "pandoc", "quarto")
+      "tz", "date", "pandoc", "quarto")
   )
 
   ## This can be a variety of strings, e.g. "R Under development"

--- a/tests/testthat/test-platform-info.R
+++ b/tests/testthat/test-platform-info.R
@@ -4,7 +4,7 @@ test_that("platform_info", {
   expect_equal(
     names(pi),
     c("version", "os", "system", "ui", "language", "collate", "ctype",
-      "tz", "date", "pandoc")
+      "tz", "date", "rstudio", "pandoc", "quarto")
   )
 
   ## This can be a variety of strings, e.g. "R Under development"

--- a/tests/testthat/test-platform-info.R
+++ b/tests/testthat/test-platform-info.R
@@ -29,3 +29,12 @@ test_that("print.platform_info ignores max.print", {
   out <- tail(strsplit(out, split = "\r?\n")[[1]], -1)
   expect_length(out, length(pi))
 })
+
+test_that("get_quarto_version", {
+  mockery::stub(get_quarto_version, "Sys.which", "")
+  expect_snapshot(get_quarto_version())
+
+  mockery::stub(get_quarto_version, "Sys.which", "/path/to/quarto")
+  mockery::stub(get_quarto_version, "system", "1.3.450")
+  expect_snapshot(get_quarto_version())
+})


### PR DESCRIPTION
This PR will add initial support for reporting the Quarto version with `session_info()` and address #75 

```r
session_info()
─ Session info ───────────────────────────────────────
 setting  value
 version  R version 4.2.0 (2022-04-22)
 os       macOS 13.3.1
 system   aarch64, darwin20
 ui       RStudio
 language (EN)
 collate  en_US.UTF-8
 ctype    en_US.UTF-8
 tz       America/Chicago
 date     2023-07-28
 rstudio  2023.09.0-daily+281 Desert Sunflower (desktop)
 pandoc   3.1.1 @ /Applications/RStudio.app/Contents/Resources/app/quarto/bin/tools/ (via rmarkdown)
 quarto   1.4.193 @ /usr/local/bin/quarto/ (via quarto)

```