### PR TITLE
Add hostname to platform_info()

### DIFF
--- a/R/platform-info.R
+++ b/R/platform-info.R
@@ -7,6 +7,8 @@
 #'   * `system`: CPU, and machine readable OS name, separated by a comma.
 #'   * `ui`: the user interface, e.g. `Rgui`, `RTerm`, etc. see `GUI`
 #'     in [base::.Platform].
+#'   * `hostname`: the name of the machine know on the network, see
+#'     `nodename` in [base::Sys.info()].
 #'   * `language`: The current language setting. The `LANGUAGE` environment
 #'     variable, if set, or `(EN)` if unset.
 #'   * `collate`: Collation rule, from the current locale.
@@ -30,6 +32,7 @@ platform_info <- function() {
     version = R.version.string,
     os = os_name(),
     system = version$system,
+    hostname = Sys.info()[["nodename"]],
     ui = .Platform$GUI,
     language = Sys.getenv("LANGUAGE", "(EN)"),
     collate = Sys.getlocale("LC_COLLATE"),

--- a/man/platform_info.Rd
+++ b/man/platform_info.Rd
@@ -14,6 +14,8 @@ A list with elements:
 \item \code{system}: CPU, and machine readable OS name, separated by a comma.
 \item \code{ui}: the user interface, e.g. \code{Rgui}, \code{RTerm}, etc. see \code{GUI}
 in \link[base:Platform]{base::.Platform}.
+\item \code{hostname}: the name of the machine know on the network, see
+\code{nodename} in \code{\link[base:Sys.info]{base::Sys.info()}}.
 \item \code{language}: The current language setting. The \code{LANGUAGE} environment
 variable, if set, or \code{(EN)} if unset.
 \item \code{collate}: Collation rule, from the current locale.
@@ -22,6 +24,7 @@ variable, if set, or \code{(EN)} if unset.
 \item \code{date}: The current date.
 \item \code{rstudio}: RStudio format string, only added in RStudio.
 \item \code{pandoc}: pandoc version and path
+\item \code{quarto}: quarto version and path
 }
 }
 \description{

--- a/tests/testthat/test-platform-info.R
+++ b/tests/testthat/test-platform-info.R
@@ -3,7 +3,7 @@ test_that("platform_info", {
   pi <- platform_info()
   expect_equal(
     names(pi),
-    c("version", "os", "system", "ui", "language", "collate", "ctype",
+    c("version", "os", "system", "hostname", "ui", "language", "collate", "ctype",
       "tz", "date", "pandoc", "quarto")
   )
 


### PR DESCRIPTION
This PR closes #98 , adding an additional line `hostname` with the output from `Sys.info()[["nodename"]]` to the `session_info()` structure.