### PR TITLE
fix: `session_info()` with empty package list

### DIFF
--- a/R/package-info.R
+++ b/R/package-info.R
@@ -227,6 +227,9 @@ abbrev_long_sha <- function(x) {
 #' @export
 
 format.packages_info <- function(x, ...) {
+  if (nrow(x) == 0) {
+    return(cli::col_grey("No packages."))
+  }
 
   unloaded <- is.na(x$loadedversion)
   flib <- function(x) ifelse(is.na(x), "?", as.integer(x))

--- a/R/session-info.R
+++ b/R/session-info.R
@@ -115,7 +115,7 @@ format.session_info <- function(x, ...) {
         ""
       )
     },
-    if ("packages" %in% names(x)) {
+    if ("packages" %in% names(x) && nrow(x$packages) > 0) {
       c(rule("Packages"), format(x$packages), "")
     },
     if ("external" %in% names(x)) {


### PR DESCRIPTION
Fixes #97

I updated `format.packages_info()` to print "No packages." when handed a data frame with 0 rows. In a second commit I also have `format.session_info()` skip printing packages in the same situation. I think both are reasonable, but either commit will solve #97.

```
❯ Rscript --vanilla -e 'sessioninfo::session_info(pkgs = "attached")'
─ Session info ──────────────────────────────────────
 setting  value
 version  R version 4.4.1 (2024-06-14)
 os       macOS Sonoma 14.5
 system   aarch64, darwin20
 ui       X11
 language (EN)
 collate  en_US.UTF-8
 ctype    en_US.UTF-8
 tz       America/Los_Angeles
 date     2024-08-15
 pandoc   3.1.11.1 @ /opt/homebrew/bin/pandoc
 quarto   1.5.55 @ /usr/local/bin/quarto

──────────────────────────────────────────────
```
