### PR TITLE
fix(parse_as_gha_url): job URL changed from `jobs/` to `job/`

### DIFF
--- a/R/github-actions.R
+++ b/R/github-actions.R
@@ -19,7 +19,7 @@ github_url_regex <- paste0(
 github_fragment_regex <- paste0(
   "/runs/",
   "(?<run_id>[0-9]+)",
-  "/jobs/",
+  "/jobs?/",
   "(?<html_id>[0-9]+)",
   "$"
 )


### PR DESCRIPTION
Fixes #89

```r
parse_as_gha_url("https://github.com/r-lib/sessioninfo/actions/runs/10251844492/job/28360805716")
#>   owner        repo      run_id     html_id
#> 1 r-lib sessioninfo 10251844492 28360805716
```

GHA updated the URL structure replacing `jobs/` with `job/` in the URL. I updated the regular expression to make the trailing `s` optional. After this fix, the following use of `session_diff()` should work again.

```r
sessioninfo::session_diff(new = "https://github.com/r-lib/sessioninfo/actions/runs/10251844492/job/28360805716")
```