### PR TITLE
Optionally use {quarto} to detect Quarto

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,6 +29,7 @@ Suggests:
     callr,
     covr,
     gh,
+    quarto (>= 1.4),
     reticulate,
     rmarkdown,
     testthat (>= 3.2.0),

--- a/R/platform-info.R
+++ b/R/platform-info.R
@@ -87,6 +87,21 @@ parse_pandoc_version <- function(path) {
 }
 
 get_quarto_version <- function() {
+  if (requireNamespace("quarto", quietly = TRUE)) {
+    path <- quarto::quarto_path()
+    ver <- try(
+      {
+        quarto::quarto_version()
+      },
+      silent = TRUE
+    )
+
+    if (inherits(ver, "try-error") || is.null(path)) {
+      return("NA")
+    }
+
+    paste0(ver, " @ ", path)
+  } else {
     path <- Sys.which("quarto")
     if (path == "") {
       "NA"
@@ -98,6 +113,7 @@ get_quarto_version <- function() {
       ver <- system2("quarto", "-V", stdout = TRUE, env = paste0("TMPDIR=", tmp))[1]
       paste0(ver, " @ ", path)
     }
+  }
 }
 
 #' @export


### PR DESCRIPTION
I use this workaround for <https://github.com/r-lib/sessioninfo/issues/112>.

Maybe you can use this as a starting point, although I doubt it because I am creating an optional dependency. 
