### PR TITLE
#112 - avoid unknown command error/warning

### DIFF
--- a/R/platform-info.R
+++ b/R/platform-info.R
@@ -98,11 +98,7 @@ get_quarto_version <- function() {
   if (path == "") {
     "NA"
   } else {
-    tmp <- tempfile()
-    on.exit(unlink(tmp, recursive = TRUE), add = TRUE)
-    dir.create(tmp, recursive = TRUE, showWarnings = FALSE)
-    tmp <- normalizePath(tmp, winslash = "/")
-    ver <- system2("quarto", "-V", stdout = TRUE, env = paste0("TMPDIR=", tmp))[
+    ver <- system2("quarto", "-V", stdout = TRUE)[
       1
     ]
     paste0(ver, " @ ", path)


### PR DESCRIPTION
I tried to keep this change as minimal as possible; it should avoid the "unknown command" error/warning message originating from the `system2` call.